### PR TITLE
Se arregla el generador del residuo para la palabra codigo y se termina la funcion para la recepcion

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,15 +1,19 @@
 import tkinter as tk
 import numpy as np
 
-def alterar_mensaje(mensaje):
+def alterar_mensaje(mensaje,generador):
     #Funcion para alterar el mensaje y de terminar si hay error o no
-    lon=len(mensaje)
+    lon=len(mensaje)-(len(generador)-2) #Se tiene en cuenta solo el mensaje y no se altera el residuo
+    mensaje_orig=mensaje.copy()
+    print("Mensaje Original",mensaje_orig)
     desea_alterar=int(input("Desea alterar el mensaje?\n 1=Si 0=No: "))
     if desea_alterar==1:                            #* Si desea alterar el mensaje
         new_array=np.random.randint(2, size=lon)
-        return new_array^mensaje                        #* Retornamos array con mensaje alterado
+        mensaje_orig[:lon] =new_array # Modidifica solo el mensaje y no el residuo
+        print("Array de bits aleatorios",new_array)
+        print("Mensaje Alterado",mensaje_orig)
+        return mensaje_orig                       #* Retornamos array con mensaje alterado
     else:
-        print("Mensaje Original",mensaje)
         return mensaje                                  #* Retornamos array con mensaje original
 def division_xor(divisor, dividendo):
 #! Codigo para hacer la division XOR
@@ -30,10 +34,9 @@ def division_xor(divisor, dividendo):
             dividendo[i:i+len(divisor)] = dividendo[i:i+len(divisor)] ^ divisor
         else:
             dividendo[i:i+len(divisor)] = dividendo[i:i +len(divisor)] ^ np.zeros(len(divisor), dtype=int)
-    adding=dividendo[-len(divisor):]
+    adding=dividendo[-(len(divisor)-1):]
+    print("Residuo Palabra codigo: ",adding)
 
-
-    
     msn=np.concatenate((dividendo_ref,adding))  #* Se concatena el mensaje con el residuo
     #msn_alter=alterar_mensaje(msn)
 
@@ -49,9 +52,12 @@ def division_xor(divisor, dividendo):
 
 def recepcion_mensaje(divisor,mensaje):
     
-
+    # Los códigos CRC no pueden detectar todos los errores. Por ejemplo,
+    # un código CRC no puede detectar una ráfaga de bits erróneos de
+    # longitud mayor que el grado del polinomio generador.
     divisor = np.array(list(divisor[2:]), dtype=int)
     dividendo = mensaje
+    Error = 0
 
     print("Mensaje recibido:", dividendo)
     
@@ -62,25 +68,19 @@ def recepcion_mensaje(divisor,mensaje):
             dividendo[i:i + len(divisor)] = dividendo[i:i + len(divisor)] ^ divisor
         else:
             dividendo[i:i + len(divisor)] = dividendo[i:i + len(divisor)] ^ np.zeros(len(divisor), dtype=int)
-        print(dividendo)
-    adding = dividendo[-len(divisor):]
+    Residuo = dividendo[-len(divisor):]
+    print("Residuo mensaje recibido:",Residuo)
+
+    for i in range(len(Residuo)):
+        if Residuo[i] == 1:
+            print("Error en el mensaje")
+            break
+        else:
+            Error+=1
+    if Error==len(Residuo):
+        print("No hay error en el mensaje")
+        
     
-
-    # msn = np.concatenate((dividendo_ref, adding))  # * Se concatena el mensaje con el residuo
-    # # msn_alter=alterar_mensaje(msn)
-
-    # # !Imprimimos Pruebas de valores
-    # # print("Residuo: ",add)
-    # # print("Divisor: ",divisor)
-    # # print("Divisor: ",dividendo)
-    # # print("Residuo: ",residuo)
-    # # print("Addicionar",adding)
-    # # print("Mensaje Original",msn)
-    # # print("Mensaje Enviado",msn_alter)
-    # return msn
-
-
-
 def pedir_datos(generador):
     trama = bin(int(input("Ingrese el mensaje que desee enviar "), 2))
     generator = generador
@@ -93,15 +93,10 @@ def pedir_datos(generador):
         # print("El mensaje enviado es: ", sent)
         #print("Mensaje Enviado",mensaje)
 def main():
-    generator="0b101"
+    generator="0b11011011"
     mensaje=pedir_datos(generator)
-    mensaje_alter=alterar_mensaje(mensaje)
+    mensaje_alter=alterar_mensaje(mensaje,generator)
    
-    
-    
-  
-    print("Mensaje Enviado",mensaje)
-    print("Mensaje Alterado",mensaje_alter)
     recepcion_mensaje(generator,mensaje_alter )
 
 


### PR DESCRIPTION
Se arregla el generador del residuo para la palabra codigo, cambiándole el tamaño a un bit menos que el codigo generador, ya que este era la causa del problema de que no se detectara si se producia un error en caso de variar el mensaje. Asi como también se termina el codigo para la recepcion del codigo, permitiendo observar mediante un mensaje si exitio o no, un error en la transmisión del mensaje